### PR TITLE
ENH Forward pass semantic encoder

### DIFF
--- a/bark.cpp
+++ b/bark.cpp
@@ -1383,7 +1383,7 @@ bark_codes bark_forward_coarse_encoder(
         gpt_eval(model, n_threads, &n_past, false, { 0, 1, 2, 3 }, logits, mem_per_token);
     }
 
-    for(int i = 0; i < n_window_steps; i++) {
+    for (int i = 0; i < n_window_steps; i++) {
         int semantic_ix = roundf(n_steps / semantic_to_coarse_ratio);
 
         bark_sequence input_in(

--- a/bark.cpp
+++ b/bark.cpp
@@ -858,6 +858,7 @@ bool gpt_eval(
               std::vector<float>          & embd_w,
               size_t                      & mem_per_token) {
     int N = embd_inp.size();
+    BARK_ASSERT(n_past != NULL);
 
     const auto & hparams = model.hparams;
 

--- a/bark.h
+++ b/bark.h
@@ -122,7 +122,7 @@ bool gpt_model_load(const std::string& fname, gpt_model& model);
 bool gpt_eval(
         const gpt_model & model,
         const int n_threads,
-        const int n_past,
+        int * n_past,
         const bool merge_ctx,
         const bark_sequence & embd_inp,
               std::vector<float>          & embd_w,
@@ -165,7 +165,6 @@ bark_sequence bark_forward_text_encoder(
     std::mt19937 & rng,
     const int n_threads,
     const float temp,
-    const bool early_stop,
     const float min_eos_p);
 
 bark_codes bark_forward_coarse_encoder(

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -40,6 +40,7 @@ bool run_test_on_sequence(logit_sequence truth, logit_sequence result) {
         if (n_violations == 0) {
             fprintf(stderr, "%s : wrong shape (%zu != %zu).\n", __func__, truth.size(), result.size());
         } else {
+            fprintf(stderr, "\n");
             fprintf(stderr, "       abs_tol=%.4f, rel_tol=%.4f, abs max viol=%.4f, viol=%.1f%%", ABS_TOL, REL_TOL, max_violation, (float)n_violations/truth.size()*100);
             fprintf(stderr, "\n");
         }

--- a/tests/test-coarse-encoder.cpp
+++ b/tests/test-coarse-encoder.cpp
@@ -41,15 +41,20 @@ int main(int argc, char** argv) {
     bool success = true;
 
     // dry run to estimate mem_per_token
-    gpt_eval(model, n_threads, 0, false, { 0, 1, 2, 3 }, logits, mem_per_token);
+    {
+        int n_past = 0;
+        gpt_eval(model, n_threads, &n_past, false, { 0, 1, 2, 3 }, logits, mem_per_token);
+    }
 
     for (int i = 0; i < (int) test_data.size(); i++) {
         bark_sequence input;
         logit_sequence truth;
         std::string path = test_data[i];
 
+        int n_past = 0;
+
         load_test_data(path, input, truth);
-        gpt_eval(model, n_threads, 0, false, input, logits, mem_per_token);
+        gpt_eval(model, n_threads, &n_past, false, input, logits, mem_per_token);
 
         fprintf(stderr, "%s", path.c_str());
         if (!run_test_on_sequence(truth, logits)) {

--- a/tests/test-text-encoder.cpp
+++ b/tests/test-text-encoder.cpp
@@ -29,7 +29,6 @@ int main(int argc, char** argv) {
 
     gpt_model model;
     const int n_threads = 4;
-    const int n_past = 0;
 
     bool success = true;
 
@@ -43,7 +42,10 @@ int main(int argc, char** argv) {
     }
 
     // dry run to estimate mem_per_token
-    gpt_eval(model, n_threads, 0, false, { 0, 1, 2, 3 }, logits, mem_per_token);
+    {
+        int n_past = 0;
+        gpt_eval(model, n_threads, &n_past, false, { 0, 1, 2, 3 }, logits, mem_per_token);
+    }
 
     for (int i = 0; i < (int) test_data.size(); i++) {
         bark_sequence input;
@@ -52,8 +54,10 @@ int main(int argc, char** argv) {
         std::string path = std::get<0>(test_data[i]);
         bool merge_ctx = std::get<1>(test_data[i]);
 
+        int n_past = 0;
+
         load_test_data(path, input, truth);
-        gpt_eval(model, n_threads, n_past, merge_ctx, input, logits, mem_per_token);
+        gpt_eval(model, n_threads, &n_past, merge_ctx, input, logits, mem_per_token);
 
         fprintf(stderr, "%s (merge context=%d)", path.c_str(), merge_ctx);
         if (!run_test_on_sequence(truth, logits)) {


### PR DESCRIPTION
Currently, there are slight discrepancies between the forward pass of the semantic encoder from the original Bark implementation and in bark.cpp . This PR removes the `early_stop` option and streamlines the update of `n_past` for the semantic encoder.