### PR TITLE
FIX Bug in fine encoder

### DIFF
--- a/tests/test-fine-encoder.cpp
+++ b/tests/test-fine-encoder.cpp
@@ -53,12 +53,12 @@ int main(int argc, char** argv) {
         bark_codes input_t = transpose(input);
         fine_gpt_eval(model, n_threads, 2, input_t, logits, mem_per_token);
 
-        fprintf(stderr, "truth : ");
-        for (int i = 0; i < 8; i++) { fprintf(stderr, "%.4f ", truth[0][i]); }
-        fprintf(stderr, "\n");
-        fprintf(stderr, "logits: ");
-        for (int i = 0; i < 8; i++) { fprintf(stderr, "%.4f ", logits[0][i]); }
-        fprintf(stderr, "\n");
+        // fprintf(stderr, "truth : ");
+        // for (int i = 0; i < 8; i++) { fprintf(stderr, "%.4f ", truth[0][i]); }
+        // fprintf(stderr, "\n");
+        // fprintf(stderr, "logits: ");
+        // for (int i = 0; i < 8; i++) { fprintf(stderr, "%.4f ", logits[0][i]); }
+        // fprintf(stderr, "\n");
 
         fprintf(stderr, "%s", path.c_str());
         if (!run_test_on_codes(truth, logits)) {


### PR DESCRIPTION
This PR fixes a bug in the fine encoder. More precisely, when inspecting the attention maps from our fine encoder and the one from the original bark implementation, we find a significant discrepancy hinting at an implementation error.