### PR TITLE
Fix model conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ In order to build bark.cpp you have two different options. We recommend using `C
 ### Prepare data & Run
 
 ```bash
-# obtain the original bark and encodec weights and place them in ./models
-python3 download_weights.py --download-dir ./models
-
 # install Python dependencies
 python3 -m pip install -r requirements.txt
+
+# obtain the original bark and encodec weights and place them in ./models
+python3 download_weights.py --download-dir ./models
 
 # convert the model to ggml format
 python3 convert.py \

--- a/download_weights.py
+++ b/download_weights.py
@@ -5,7 +5,7 @@ from huggingface_hub import hf_hub_download
 import torch
 
 
-ENCODEC_PATH = Path("https://dl.fbaipublicfiles.com/encodec/v0/encodec_24khz-d7cc33bc.th")
+ENCODEC_PATH = "https://dl.fbaipublicfiles.com/encodec/v0/encodec_24khz-d7cc33bc.th"
 
 REMOTE_MODEL_PATHS = {
     "text": {
@@ -39,11 +39,11 @@ if __name__ == "__main__":
 
     print(" ### Downloading EnCodec weights...")
     state_dict = torch.hub.load_state_dict_from_url(
-        str(ENCODEC_PATH),
+        ENCODEC_PATH,
         map_location="cpu",
         check_hash=True
     )
-    with open(out_dir / ENCODEC_PATH.name, "wb") as fout:
+    with open(out_dir / Path(ENCODEC_PATH).name, "wb") as fout:
         torch.save(state_dict, fout)
 
     print("Done.")


### PR DESCRIPTION
I've had this error on macOS and fixed it in this pr:
```
Downloading: "https:/dl.fbaipublicfiles.com/encodec/v0/encodec_24khz-d7cc33bc.th" to /Users/vietanhdev/.cache/torch/hub/checkpoints/encodec_24khz-d7cc33bc.th
Traceback (most recent call last):
  File "download_weights.py", line 41, in <module>
    state_dict = torch.hub.load_state_dict_from_url(
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bark/lib/python3.8/site-packages/torch/hub.py", line 746, in load_state_dict_from_url
    download_url_to_file(url, cached_file, hash_prefix, progress=progress)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bark/lib/python3.8/site-packages/torch/hub.py", line 611, in download_url_to_file
    u = urlopen(req)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bark/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bark/lib/python3.8/urllib/request.py", line 522, in open
    req = meth(req)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bark/lib/python3.8/urllib/request.py", line 1278, in do_request_
    raise URLError('no host given')
urllib.error.URLError: <urlopen error no host given>
```

For the running model conversion, I'm still missing `vocab.txt` and need to comment following part to convert the model successfully:

```
    # generate_vocab_file(vocab_path, out_dir / "ggml_vocab.bin")
    # print(" Vocab loaded.")
```