### PR TITLE
FIX Encodec tests

### DIFF
--- a/bark.cpp
+++ b/bark.cpp
@@ -1694,19 +1694,12 @@ bool encodec_eval(
         memcpy((void *) ((char *) codes->data + offset), _tmp.data(), N*ggml_element_size(codes));
     }
 
-    struct ggml_tensor * toy;
-
     struct ggml_tensor * quantized_out = encodec_quantizer_decode_eval(ctx0, model, codes);
-    struct ggml_tensor * output        = encodec_decoder_eval(ctx0, model, quantized_out, &toy);
+    struct ggml_tensor * output        = encodec_decoder_eval(ctx0, model, quantized_out);
 
     ggml_build_forward_expand(&gf, output);
-    // TODO: adapt ggml_conv_1d and ggml_conv_trans_1d implementation to use multiple
-    // threads.
+    // TODO: adapt ggml_conv_1d implementation to use multiple threads.
     ggml_graph_compute_with_ctx(ctx0, &gf, 1);
-
-    if (toy) {
-        dump_tensor(toy, false);
-    }
 
     int out_seq_length = output->ne[0];
     audio_arr.resize(out_seq_length);

--- a/bark.cpp
+++ b/bark.cpp
@@ -1179,7 +1179,7 @@ bool gpt_eval(
             cur = ggml_add(ctx0,
                     ggml_repeat(ctx0, model.layers[il].c_mlp_fc_b, cur),
                     cur);
-            
+
             // GELU activation
             // [3072, N]
             cur = ggml_gelu(ctx0, cur);
@@ -1657,7 +1657,7 @@ bool encodec_eval(
     static void * buf = malloc(buf_size);
 
     if (mem_per_token > 0 && mem_per_token*N*n_codes > buf_size) {
-        const size_t buf_size_new = 1.1*(mem_per_token*N*n_codes);  // add 10% to account for ggml object overhead
+        const size_t buf_size_new = 1.2*(mem_per_token*N*n_codes);  // add 10% to account for ggml object overhead
 
         // reallocate
         buf_size = buf_size_new;
@@ -1730,8 +1730,8 @@ audio_arr_t bark_forward_encodec(const bark_codes & tokens, const encodec_model 
     const int64_t t_main_end_us = ggml_time_us();
 
     printf("\n\n");
-    printf("%s: mem per token = %zu bytes\n", __func__, mem_per_token);
-    printf("%s:  predict time = %8.2f ms / %.2f ms per token\n", __func__, t_predict_us/1000.0f, t_predict_us/1000.0f);
+    printf("%s: mem per token = %8.2f MB\n", __func__, mem_per_token);
+    printf("%s:  predict time = %8.2f ms\n", __func__, t_predict_us/1000.0f);
     printf("%s:    total time = %8.2f ms\n", __func__, (t_main_end_us - t_main_start_us)/1000.0f);
 
     return audio_arr;

--- a/bark.h
+++ b/bark.h
@@ -232,7 +232,7 @@ bool bark_params_parse(int argc, char ** argv, bark_params & params);
 
 void bark_print_usage(char ** argv, const bark_params & params);
 
-void print_tensor(struct ggml_tensor * a);
+void dump_tensor(struct ggml_tensor * a, bool print_val);
 
 void read_tensor_from_file(std::ifstream & fin, struct ggml_tensor * t);
 

--- a/encodec.cpp
+++ b/encodec.cpp
@@ -181,6 +181,9 @@ static struct ggml_tensor * strided_conv_transpose_1d(
 
     struct ggml_tensor * dst = transpose_conv_1d(ctx0, inp, conv_w, stride);
 
+    printf("dst=[%lld, %lld]\n", dst->ne[0], dst->ne[1]);
+    printf("conv_b=[%lld, %lld]\n", conv_b->ne[0], conv_b->ne[1]);
+
     // add bias
     dst = ggml_transpose(ctx0, dst);
     dst = ggml_add(ctx0, ggml_repeat(ctx0, conv_b, dst), dst);
@@ -490,8 +493,7 @@ struct ggml_tensor * encodec_quantizer_decode_eval(
 struct ggml_tensor * encodec_decoder_eval(
                     struct ggml_context * ctx0,
                     const encodec_model & model,
-                    struct ggml_tensor  * quantized_out,
-                    struct ggml_tensor  ** toy) {
+                    struct ggml_tensor  * quantized_out) {
     const auto & hparams = model.hparams;
     const int * ratios   = hparams.ratios;
     const int stride     = hparams.stride;
@@ -524,9 +526,6 @@ struct ggml_tensor * encodec_decoder_eval(
 
         inpL = strided_conv_transpose_1d(
             ctx0, inpL, block.us_conv_w, block.us_conv_b, ratios[layer_ix]);
-
-        if (layer_ix == 0)
-            *toy = inpL;
 
         struct ggml_tensor * current = inpL;
 

--- a/encodec.cpp
+++ b/encodec.cpp
@@ -446,7 +446,8 @@ struct ggml_tensor * encodec_quantizer_decode_eval(
 struct ggml_tensor * encodec_decoder_eval(
                     struct ggml_context * ctx0,
                     const encodec_model & model,
-                    struct ggml_tensor  * quantized_out) {
+                    struct ggml_tensor  * quantized_out,
+                    struct ggml_tensor  ** toy) {
     const auto & hparams = model.hparams;
     const int * ratios   = hparams.ratios;
     const int stride     = hparams.stride;
@@ -479,6 +480,9 @@ struct ggml_tensor * encodec_decoder_eval(
 
         inpL = strided_conv_transpose_1d(
             ctx0, inpL, block.us_conv_w, block.us_conv_b, ratios[layer_ix]);
+
+        if (layer_ix == 0)
+            *toy = inpL;
 
         struct ggml_tensor * current = inpL;
 

--- a/encodec.h
+++ b/encodec.h
@@ -135,4 +135,5 @@ struct ggml_tensor * encodec_quantizer_decode_eval(
 struct ggml_tensor * encodec_decoder_eval(
                         struct ggml_context * ctx0,
                         const encodec_model & model,
-                        struct ggml_tensor  * quantized_out);
+                        struct ggml_tensor  * quantized_out,
+                        struct ggml_tensor  ** toy);

--- a/encodec.h
+++ b/encodec.h
@@ -135,5 +135,4 @@ struct ggml_tensor * encodec_quantizer_decode_eval(
 struct ggml_tensor * encodec_decoder_eval(
                         struct ggml_context * ctx0,
                         const encodec_model & model,
-                        struct ggml_tensor  * quantized_out,
-                        struct ggml_tensor  ** toy);
+                        struct ggml_tensor  * quantized_out);

--- a/ggml.c
+++ b/ggml.c
@@ -12883,11 +12883,7 @@ static void ggml_compute_forward_conv_1d_f32(
                 const float * const src = (float *)((char *) src1->data + i11*nb11);
                 float * dst_data = wdata;
                 for (int64_t i10 = 0; i10 < ne10 + 2*p0; i10++) {
-                    if ((i10 < p0) || (i10 >= ne10 + p0)) {
-                        dst_data[i10*ew0 + i11] = 0.f;  // padding
-                    } else {
-                        dst_data[i10*ew0 + i11] = src[i10];
-                    }
+                    dst_data[i10*ew0 + i11] = src[i10];
                 }
             }
         }
@@ -12915,9 +12911,12 @@ static void ggml_compute_forward_conv_1d_f32(
             dst_data[i0/s0] = 0;
             for (int k = 0; k < nk; k++) {
                 float v = 0.0f;
-                ggml_vec_dot_f32(ew0, &v,
-                        (float *) params->wdata +   i1*ew0*ne00 +      (k)*ew0,
-                        (float *) params->wdata + ne02*ew0*ne00 + (i0 + k)*ew0);
+                if ((i0 + k >= p0) && (i0 + k < p0 + ne10)) {
+                    ggml_vec_dot_f32(ew0, &v,
+                            (float *) params->wdata +   i1*ew0*ne00 +      (k)*ew0,
+                            (float *) params->wdata + ne02*ew0*ne00 + (i0 + k)*ew0);
+                }
+                printf("%.4f\n", v);
                 dst_data[i0/s0] += v;
             }
         }

--- a/ggml.c
+++ b/ggml.c
@@ -12882,7 +12882,7 @@ static void ggml_compute_forward_conv_1d_f32(
             for (int64_t i11 = 0; i11 < ne11; i11++) {
                 const float * const src = (float *)((char *) src1->data + i11*nb11);
                 float * dst_data = wdata;
-                for (int64_t i10 = 0; i10 < ne10 + 2*p0; i10++) {
+                for (int64_t i10 = 0; i10 < ne10; i10++) {
                     dst_data[i10*ew0 + i11] = src[i10];
                 }
             }
@@ -12913,10 +12913,9 @@ static void ggml_compute_forward_conv_1d_f32(
                 float v = 0.0f;
                 if ((i0 + k >= p0) && (i0 + k < p0 + ne10)) {
                     ggml_vec_dot_f32(ew0, &v,
-                            (float *) params->wdata +   i1*ew0*ne00 +      (k)*ew0,
-                            (float *) params->wdata + ne02*ew0*ne00 + (i0 + k)*ew0);
+                            (float *) params->wdata +   i1*ew0*ne00 +       (k)*ew0,
+                            (float *) params->wdata + ne02*ew0*ne00 + (i0+k-p0)*ew0);
                 }
-                printf("%.4f\n", v);
                 dst_data[i0/s0] += v;
             }
         }

--- a/ggml.h
+++ b/ggml.h
@@ -1127,6 +1127,10 @@ extern "C" {
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
 
+    GGML_API struct ggml_tensor * ggml_flip_inplace(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a);
+
     GGML_API struct ggml_tensor * ggml_get_rows(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,

--- a/ggml.h
+++ b/ggml.h
@@ -356,7 +356,6 @@ extern "C" {
         GGML_OP_VIEW,
         GGML_OP_PERMUTE,
         GGML_OP_TRANSPOSE,
-        GGML_OP_FLIP,
         GGML_OP_GET_ROWS,
         GGML_OP_GET_ROWS_BACK,
         GGML_OP_DIAG,
@@ -411,6 +410,7 @@ extern "C" {
         GGML_UNARY_OP_GELU,
         GGML_UNARY_OP_GELU_QUICK,
         GGML_UNARY_OP_SILU,
+        GGML_UNARY_OP_FLIP
     };
 
     enum ggml_object_type {

--- a/ggml.h
+++ b/ggml.h
@@ -356,6 +356,7 @@ extern "C" {
         GGML_OP_VIEW,
         GGML_OP_PERMUTE,
         GGML_OP_TRANSPOSE,
+        GGML_OP_INTERLEAVE,
         GGML_OP_GET_ROWS,
         GGML_OP_GET_ROWS_BACK,
         GGML_OP_DIAG,
@@ -1115,7 +1116,13 @@ extern "C" {
     GGML_API struct ggml_tensor * ggml_transpose(
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
-    
+
+    GGML_API struct ggml_tensor * ggml_interleave(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,
+            int                   n_repeat,
+            float                 value);
+
     GGML_API struct ggml_tensor * ggml_flip(
             struct ggml_context * ctx,
             struct ggml_tensor  * a);

--- a/ggml.h
+++ b/ggml.h
@@ -373,7 +373,6 @@ extern "C" {
         GGML_OP_POOL_1D,
         GGML_OP_POOL_2D,
         GGML_OP_PAD_REFLEC_1D,
-        GGML_OP_TRANS_CONV_1D,
 
         GGML_OP_FLASH_ATTN,
         GGML_OP_FLASH_FF,
@@ -1303,14 +1302,6 @@ extern "C" {
             int                   s1,
             int                   p0,
             int                   p1);
-
-    GGML_API struct ggml_tensor * ggml_transpose_conv_1d(
-            struct ggml_context * ctx,
-            struct ggml_tensor  * a,
-            struct ggml_tensor  * b,
-            int                   s0,  // stride
-            int                   p0,  // padding
-            int                   d0); // dilation
 
     GGML_API struct ggml_tensor * ggml_pad_reflec_1d(
             struct ggml_context * ctx,

--- a/ggml.h
+++ b/ggml.h
@@ -356,6 +356,7 @@ extern "C" {
         GGML_OP_VIEW,
         GGML_OP_PERMUTE,
         GGML_OP_TRANSPOSE,
+        GGML_OP_FLIP,
         GGML_OP_GET_ROWS,
         GGML_OP_GET_ROWS_BACK,
         GGML_OP_DIAG,
@@ -1113,6 +1114,10 @@ extern "C" {
 
     // alias for ggml_permute(ctx, a, 1, 0, 2, 3)
     GGML_API struct ggml_tensor * ggml_transpose(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a);
+    
+    GGML_API struct ggml_tensor * ggml_flip(
             struct ggml_context * ctx,
             struct ggml_tensor  * a);
 

--- a/tests/test-forward-encodec.cpp
+++ b/tests/test-forward-encodec.cpp
@@ -7,9 +7,10 @@
 #include "common.h"
 
 static const std::vector<std::string> test_data = {
-    "./data/encodec/test_pass_encodec_1.bin",   // prompt: El hombre que se levanta es aún más grande que el que no ha caído.
-    "./data/encodec/test_pass_encodec_2.bin",   // prompt: ♪ Heal the world, Make it a better place, For you and for me, and the entire human race ♪
-    "./data/encodec/test_pass_encodec_3.bin",   // prompt: En été, mieux vaut suer que trembler.
+    // "./data/encodec/test_pass_encodec_1.bin",   // prompt: El hombre que se levanta es aún más grande que el que no ha caído.
+    // "./data/encodec/test_pass_encodec_2.bin",   // prompt: ♪ Heal the world, Make it a better place, For you and for me, and the entire human race ♪
+    // "./data/encodec/test_pass_encodec_3.bin",   // prompt: En été, mieux vaut suer que trembler.
+    "./data/encodec/test_pass_encodec_4.bin",   // prompt: we are living on earth
 };
 
 int main() {

--- a/tests/test-forward-encodec.cpp
+++ b/tests/test-forward-encodec.cpp
@@ -22,12 +22,11 @@ int main() {
     }
 
     bark_codes tokens;
-    audio_arr_t gt_audio_arr, audio_arr;
+    audio_arr_t gt_audio_arr;
 
     for (int i = 0; i < (int) test_data.size(); i++) {
         tokens.clear();
         gt_audio_arr.clear();
-        audio_arr.clear();
 
         std::string path = test_data[i];
         load_test_data(path, tokens, gt_audio_arr);


### PR DESCRIPTION
Currently, out of the 3 Encodec tests, 2 pass and one fail:

```
bark_forward_encodec: mem per token =     0.00 MB
bark_forward_encodec:  predict time =  1130.08 ms
bark_forward_encodec:    total time =  1198.17 ms

main: ./data/encodec/test_pass_encodec_1.bin
main:     test 1 passed.

bark_forward_encodec: mem per token =     0.00 MB
bark_forward_encodec:  predict time =  3756.10 ms
bark_forward_encodec:    total time =  3796.49 ms

main: ./data/encodec/test_pass_encodec_2.bin
main:     test 2 passed.

bark_forward_encodec: mem per token =     0.00 MB
bark_forward_encodec:  predict time =   681.15 ms
bark_forward_encodec:    total time =   770.30 ms

main: ./data/encodec/test_pass_encodec_3.bin
run_test: abs_tol=0.0010, abs max viol=38923531967525382011995815936.0000, viol=100.0%
main:     test 3 failed.
``` 

Oddly enough, when I only run test 3, it passes without any problem. 

```
bark_forward_encodec: mem per token =     0.00 MB
bark_forward_encodec:  predict time =   572.53 ms
bark_forward_encodec:    total time =   632.48 ms

main: ./data/encodec/test_pass_encodec_3.bin
main:     test 1 passed.
```

I suspect there's a problem when cleaning the memory ctxs. 