### PR TITLE
Update README.md to include instructions on grabbing ggml submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ cd bark.cpp
 
 ### Pull submodules (ggml)
 ```bash
-git submodule update --recursive --remote
+git submodule update --init --recursive
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ cd bark.cpp
 
 ### Pull submodules (ggml)
 ```bash
-git submodule update --init --recursive
+git clone --recursive https://github.com/PABannier/bark.cpp.git
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ git clone https://github.com/PABannier/bark.cpp.git
 cd bark.cpp
 ```
 
+### Pull submodules (ggml)
+```bash
+git submodule update --recursive --remote
+```
+
 ### Build
 
 In order to build bark.cpp you must use `CMake`:


### PR DESCRIPTION
A simple change. 

the instructions didn't mention pulling the ggml submodule. 