### PR TITLE
Fix main build errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ python3 bark/convert.py \
         --vocab-path ./ggml_weights/ \
         --out-dir ./ggml_weights/
 
+# convert the encodec model to ggml format
+python ./encodec.cpp/convert.py \
+    --dir-model ./models/ \
+    --out-dir ./ggml_weights/ \
+    --use-f16
+    
 # run the inference
 ./bark/build/examples/main/main -m ./ggml_weights/ -p "this is an audio"
 ```

--- a/bark/bark.cpp
+++ b/bark/bark.cpp
@@ -2045,7 +2045,7 @@ bool bark_generate_audio(
     const std::string encodec_model_path = bctx->encodec_model_path;
 
     struct encodec_context * ectx = encodec_load_model(
-        encodec_model_path, n_gpu_layers, encodec_verbosity_level::LOW);
+        encodec_model_path, n_gpu_layers);
     if (!ectx) {
         printf("%s: error during loading encodec model\n", __func__);
         return false;


### PR DESCRIPTION
Propose changes:
- add fix for following error:
```
bark.cpp/bark/bark.cpp:2048:43: error: use of undeclared identifier 'encodec_verbosity_level'; did you mean 'bark_verbosity_level'?
        encodec_model_path, n_gpu_layers, encodec_verbosity_level::LOW);
                                          ^~~~~~~~~~~~~~~~~~~~~~~
                                          bark_verbosity_level
/oos/bark.cpp/bark/./bark.h:23:12: note: 'bark_verbosity_level' declared here
```
- add doc to convert encodec.cpp weight to ggml