### PR TITLE
Increase stack size to 10MB for Visual Studio compilation

### DIFF
--- a/examples/main/CMakeLists.txt
+++ b/examples/main/CMakeLists.txt
@@ -5,4 +5,5 @@ target_compile_features(${TARGET} PRIVATE cxx_std_11)
 
 if(MSVC)
     target_compile_definitions(${TARGET} PRIVATE -D_CRT_SECURE_NO_WARNINGS=1)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
 endif()

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -6,4 +6,5 @@ target_link_libraries(${TARGET} PRIVATE bark ${CMAKE_THREAD_LIBS_INIT})
 
 if (WIN32)
     target_link_libraries(${TARGET} PRIVATE ws2_32)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
 endif()

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -6,5 +6,7 @@ target_link_libraries(${TARGET} PRIVATE bark ${CMAKE_THREAD_LIBS_INIT})
 
 if (WIN32)
     target_link_libraries(${TARGET} PRIVATE ws2_32)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
+    if(MSVC)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10485760")
+    endif()
 endif()


### PR DESCRIPTION
Visual Studio defaults to 1MB stack size, which causes a stack overflow when running the bark executable.  This increases the stack size to 10MB when compiling with Visual Studio.